### PR TITLE
Fix test definitions

### DIFF
--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -51,7 +51,7 @@ class mod_mediagallery_base_testcase extends advanced_testcase {
     /**
      * Setup function - we will create a course and add a mediagallery instance to it.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         global $DB;
 
         $this->resetAfterTest(true);

--- a/tests/collection_test.php
+++ b/tests/collection_test.php
@@ -51,7 +51,7 @@ class mod_mediagallery_collection_testcase extends advanced_testcase {
     /**
      * Setup function - we will create a course and add a mediagallery instance to it.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         global $DB;
 
         $this->resetAfterTest(true);

--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -46,7 +46,7 @@ class mod_mediagallery_privacy_testcase extends provider_testcase {
 
     use \mod_mediagallery\privacy\subcontext_info;
 
-    public function setUp() {
+    public function setUp(): void {
         $this->resetAfterTest();
     }
 


### PR DESCRIPTION
In Moodle 3.11, phpunit will throw errors because of the lack of typehinting in tests. This PR updates the definitions to include the typehinting.