### PR TITLE
Code check fixes and GitHub Actions CI script

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,0 +1,133 @@
+# Based on <https://github.com/moodlehq/moodle-plugin-ci/blob/master/gha.dist.yml>
+# and <https://moodlehq.github.io/moodle-plugin-ci/GHAFileExplained.html>
+
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:13 # Moodle 4.2: >=13
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10.6 # Moodle 4.2: >=10.6.7
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Moodle 4.0, PHP 7.3, PostgreSQL
+          - php: '7.3' # 7.3-8.0
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: pgsql
+            plugin-ci: ^3
+          # Moodle 4.1, PHP 7.4, MariaDB
+          - php: '7.4' # 7.4-8.1
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+            plugin-ci: ^4
+          # Moodle 4.2, PHP 8.0, PostgreSQL
+          - php: '8.0' # 8.0-8.1
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: pgsql
+            plugin-ci: ^4
+          # Moodle master, PHP 8.1, MariaDB
+          - php: '8.1'
+            moodle-branch: 'master'
+            database: mariadb
+            plugin-ci: ^4
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
+          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ${{ matrix.plugin-ci }}
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0
+
+      #- name: Moodle PHPDoc Checker
+      #  if: ${{ always() }}
+      #  run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      #- name: Grunt
+      #  if: ${{ always() }}
+      #  run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning
+
+      #- name: Behat features
+      #  if: ${{ always() }}
+      #  run: moodle-plugin-ci behat --profile chrome

--- a/backup/moodle2/backup_mediagallery_activity_task.class.php
+++ b/backup/moodle2/backup_mediagallery_activity_task.class.php
@@ -28,8 +28,9 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/mod/mediagallery/backup/moodle2/backup_mediagallery_stepslib.php');
 
 /**
- * certificate backup task that provides all the settings and steps to perform one
- * complete backup of the activity
+ * mediagallery backup task
+ *
+ * Provides all the settings and steps to perform one complete backup of the activity.
  */
 class backup_mediagallery_activity_task extends backup_activity_task {
 
@@ -54,7 +55,7 @@ class backup_mediagallery_activity_task extends backup_activity_task {
      * @param string $content
      * @return string
      */
-    static public function encode_content_links($content) {
+    public static function encode_content_links($content) {
         global $CFG;
 
         $base = preg_quote($CFG->wwwroot, "/");

--- a/backup/moodle2/backup_mediagallery_stepslib.php
+++ b/backup/moodle2/backup_mediagallery_stepslib.php
@@ -23,8 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Define the complete mediagallery structure for backup, with file and id annotations
  */

--- a/backup/moodle2/restore_mediagallery_activity_task.class.php
+++ b/backup/moodle2/restore_mediagallery_activity_task.class.php
@@ -28,8 +28,9 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/mod/mediagallery/backup/moodle2/restore_mediagallery_stepslib.php');
 
 /**
- * mediagallery restore task that provides all the settings and steps to perform one
- * complete restore of the activity
+ * mediagallery restore task
+ *
+ * Provides all the settings and steps to perform one complete restore of the activity.
  */
 class restore_mediagallery_activity_task extends restore_activity_task {
 
@@ -52,7 +53,7 @@ class restore_mediagallery_activity_task extends restore_activity_task {
      * Define the contents in the activity that must be
      * processed by the link decoder
      */
-    static public function define_decode_contents() {
+    public static function define_decode_contents() {
         $contents = array();
         return $contents;
     }
@@ -61,7 +62,7 @@ class restore_mediagallery_activity_task extends restore_activity_task {
      * Define the decoding rules for links belonging
      * to the activity to be executed by the link decoder
      */
-    static public function define_decode_rules() {
+    public static function define_decode_rules() {
         $rules = array();
 
         $rules[] = new restore_decode_rule('MEDIAGALLERYVIEWBYID', '/mod/mediagallery/view.php?id=$1', 'course_module');
@@ -73,11 +74,11 @@ class restore_mediagallery_activity_task extends restore_activity_task {
 
     /**
      * Define the restore log rules that will be applied
-     * by the {@link restore_logs_processor} when restoring
+     * by the {@see \restore_logs_processor} when restoring
      * page logs. It must return one array
-     * of {@link restore_log_rule} objects
+     * of {@see \restore_log_rule} objects
      */
-    static public function define_restore_log_rules() {
+    public static function define_restore_log_rules() {
         $rules = array();
 
         $rules[] = new restore_log_rule('mediagallery', 'add', 'view.php?id={course_module}', '{page}');
@@ -89,15 +90,15 @@ class restore_mediagallery_activity_task extends restore_activity_task {
 
     /**
      * Define the restore log rules that will be applied
-     * by the {@link restore_logs_processor} when restoring
+     * by the {@see \restore_logs_processor} when restoring
      * course logs. It must return one array
-     * of {@link restore_log_rule} objects
+     * of {@see \restore_log_rule} objects
      *
      * Note this rules are applied when restoring course logs
      * by the restore final task, but are defined here at
      * activity level. All them are rules not linked to any module instance (cmid = 0)
      */
-    static public function define_restore_log_rules_for_course() {
+    public static function define_restore_log_rules_for_course() {
         $rules = array();
 
         $rules[] = new restore_log_rule('mediagallery', 'view all', 'index.php?id={course}', null);

--- a/backup/moodle2/restore_mediagallery_stepslib.php
+++ b/backup/moodle2/restore_mediagallery_stepslib.php
@@ -23,8 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Define all the restore steps that will be used by the restore_mediagallery_activity_task
  */
@@ -54,8 +52,10 @@ class restore_mediagallery_activity_structure_step extends restore_activity_stru
             $paths[] = $userfeedback;
 
             $paths[] = new restore_path_element('mediagallery_ctag', '/activity/mediagallery/collectiontags/collectiontag');
-            $paths[] = new restore_path_element('mediagallery_gtag', '/activity/mediagallery/gallerys/gallery/gallerytags/gallerytag');
-            $paths[] = new restore_path_element('mediagallery_itag', '/activity/mediagallery/gallerys/gallery/items/item/itemtags/itemtag');
+            $paths[] = new restore_path_element('mediagallery_gtag',
+                                                '/activity/mediagallery/gallerys/gallery/gallerytags/gallerytag');
+            $paths[] = new restore_path_element('mediagallery_itag',
+                                                '/activity/mediagallery/gallerys/gallery/items/item/itemtags/itemtag');
         }
 
         // Return the paths wrapped into standard activity structure.

--- a/classes/base.php
+++ b/classes/base.php
@@ -16,6 +16,16 @@
 
 namespace mod_mediagallery;
 
+/**
+ * Base class for Media collection objects
+ *
+ * @property-read string $id
+ * @property-read string $userid
+ * @property-read string $objectid
+ * @property-read string $source
+ * @property-read string $creator
+ * @property-read string $agents
+ */
 abstract class base {
 
     const POS_BOTTOM = 0;
@@ -63,7 +73,7 @@ abstract class base {
      * Create a new object in the db.
      *
      * @param \stdClass $data
-     * @return mixed
+     * @return static
      */
     public static function create(\stdClass $data) {
         global $DB, $USER;
@@ -95,7 +105,7 @@ abstract class base {
     /**
      * Get a copy of the record as it appears in the db.
      *
-     * @return stdClass The item record.
+     * @return \stdClass The item record.
      */
     public function get_record() {
         return clone $this->record;
@@ -104,7 +114,7 @@ abstract class base {
     /**
      * Retrieve the current set of tags for this object.
      *
-     * @return string CSV list of tags.
+     * @return \core_tag_tag[] CSV list of tags.
      */
     public function get_tags() {
         return \core_tag_tag::get_item_tags('mod_mediagallery', static::$table, $this->id);
@@ -135,7 +145,7 @@ abstract class base {
     /**
      * Update the item based on object record.
      *
-     * @param stdClass $data Object with all the details on the item (likely from the item_form.php form).
+     * @param \stdClass $data Object with all the details on the item (likely from the item_form.php form).
      */
     public function update($data) {
         global $DB;

--- a/classes/base.php
+++ b/classes/base.php
@@ -16,8 +16,6 @@
 
 namespace mod_mediagallery;
 
-defined('MOODLE_INTERNAL') || die();
-
 abstract class base {
 
     const POS_BOTTOM = 0;
@@ -63,6 +61,9 @@ abstract class base {
 
     /**
      * Create a new object in the db.
+     *
+     * @param \stdClass $data
+     * @return mixed
      */
     public static function create(\stdClass $data) {
         global $DB, $USER;
@@ -94,7 +95,7 @@ abstract class base {
     /**
      * Get a copy of the record as it appears in the db.
      *
-     * @returns stdClass The item record.
+     * @return stdClass The item record.
      */
     public function get_record() {
         return clone $this->record;
@@ -103,7 +104,6 @@ abstract class base {
     /**
      * Retrieve the current set of tags for this object.
      *
-     * @access public
      * @return string CSV list of tags.
      */
     public function get_tags() {
@@ -135,7 +135,7 @@ abstract class base {
     /**
      * Update the item based on object record.
      *
-     * @param $data stdClass Object with all the details on the item (likely from the item_form.php form).
+     * @param stdClass $data Object with all the details on the item (likely from the item_form.php form).
      */
     public function update($data) {
         global $DB;
@@ -191,8 +191,6 @@ abstract class base {
     /**
      * Checks for the assignsubmission_mediagallery plugin.
      *
-     * @static
-     * @access public
      * @return bool
      */
     public static function is_assignsubmission_mediagallery_installed() {

--- a/classes/collection.php
+++ b/classes/collection.php
@@ -257,7 +257,7 @@ class collection extends base {
     /**
      * Get a list of all the gallery's associated with this collection.
      *
-     * @param mixed $filterbymode If this is a non-empty string, only galleries of the specified mode are returned.
+     * @param string|bool $filterbymode If this is a non-empty string, only galleries of the specified mode are returned.
      * @return array of gallery objects
      */
     public function get_galleries($filterbymode = false) {
@@ -464,8 +464,7 @@ class collection extends base {
      * This function is used to update the new userid field during module
      * upgrade.
      *
-     * @return mixed bool|int   Returns the userid of the creator, or false if
-     * not found.
+     * @return bool|int   Returns the userid of the creator, or false if not found.
      */
     public function get_userid_from_logs() {
         global $DB;

--- a/classes/collection.php
+++ b/classes/collection.php
@@ -21,6 +21,18 @@ namespace mod_mediagallery;
  *
  * This class contains functions for manipulating and getting information for
  * the galleries that belong to a specific mediagallery activity.
+ *
+ * @property-read string $course
+ * @property-read string $name
+ * @property-read string $colltype
+ * @property-read string $galleryfocus
+ * @property-read string $carousel
+ * @property-read string $grid
+ * @property-read string $gridrows
+ * @property-read string $gridcolumns
+ * @property-read string $enforcedefaults
+ * @property-read string $maxgalleries
+ * @property-read string $mode
  */
 class collection extends base {
 

--- a/classes/collection.php
+++ b/classes/collection.php
@@ -16,9 +16,9 @@
 
 namespace mod_mediagallery;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
+ * Collection class
+ *
  * This class contains functions for manipulating and getting information for
  * the galleries that belong to a specific mediagallery activity.
  */
@@ -49,7 +49,12 @@ class collection extends base {
     }
 
     /**
+     * Create
+     *
      * Here for completeness, but new collections should be created via course mod_form interface.
+     *
+     * @param \stdClass $data
+     * @return collection
      */
     public static function create(\stdClass $data) {
         global $DB, $USER;
@@ -240,8 +245,7 @@ class collection extends base {
     /**
      * Get a list of all the gallery's associated with this collection.
      *
-     * @access public
-     * @param $filterbymode mixed If this is a non-empty string, only galleries of the specified mode are returned.
+     * @param mixed $filterbymode If this is a non-empty string, only galleries of the specified mode are returned.
      * @return array of gallery objects
      */
     public function get_galleries($filterbymode = false) {
@@ -345,7 +349,6 @@ class collection extends base {
     /**
      * Has the current user submitted this to the linked assignment?
      *
-     * @access public
      * @return bool
      */
     public function has_submitted() {
@@ -378,7 +381,6 @@ class collection extends base {
     /**
      * Get the ID of the linked assign coursemodule if one exists.
      *
-     * @access public
      * @return int|bool Returns the cmid of the linked assign, false otherwise.
      */
     public function get_linked_assignid() {
@@ -397,7 +399,6 @@ class collection extends base {
     /**
      * Is this collection able to be used as part of an assignment.
      *
-     * @access public
      * @return bool
      */
     public function is_assessable() {
@@ -410,7 +411,6 @@ class collection extends base {
      * Returns true if this collection is readonly for the current user.
      * Users with the mod/mediagallery:manage cap can always edit the collection.
      *
-     * @access public
      * @return bool true if read only for this user.
      */
     public function is_read_only() {
@@ -452,9 +452,6 @@ class collection extends base {
      * This function is used to update the new userid field during module
      * upgrade.
      *
-     * @param int $collectionid
-     * @param int $courseid
-     * @access public
      * @return mixed bool|int   Returns the userid of the creator, or false if
      * not found.
      */
@@ -508,7 +505,6 @@ class collection extends base {
      * Accounts for the max gallery limit and how many they or their group already has.
      *
      * @param int $userid
-     * @access public
      * @return bool
      */
     public function user_can_add_children($userid = null) {

--- a/classes/event/collection_deleted.php
+++ b/classes/event/collection_deleted.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery collection deleted event class.
  *

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -23,7 +23,6 @@
  */
 
 namespace mod_mediagallery\event;
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * The mod_mediagallery instance list viewed event class.

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery viewed event class.
  *

--- a/classes/event/gallery_created.php
+++ b/classes/event/gallery_created.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery gallery created event class.
  *

--- a/classes/event/gallery_deleted.php
+++ b/classes/event/gallery_deleted.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery gallery deleted event class.
  *

--- a/classes/event/gallery_updated.php
+++ b/classes/event/gallery_updated.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery gallery updated event class.
  *

--- a/classes/event/gallery_viewed.php
+++ b/classes/event/gallery_viewed.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery gallery viewed event class.
  *

--- a/classes/event/item_created.php
+++ b/classes/event/item_created.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery item created event class.
  *

--- a/classes/event/item_deleted.php
+++ b/classes/event/item_deleted.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery item deleted event class.
  *

--- a/classes/event/item_updated.php
+++ b/classes/event/item_updated.php
@@ -25,8 +25,6 @@
 
 namespace mod_mediagallery\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_mediagallery item updated event class.
  *

--- a/classes/file_info.php
+++ b/classes/file_info.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * File browsing support class.
  *
@@ -54,9 +52,9 @@ class mod_mediagallery_file_info extends file_info {
      */
     public function __construct($browser, $course, $cm, $context, $areas, $filearea) {
         parent::__construct($browser, $context);
-        $this->course   = $course;
-        $this->cm       = $cm;
-        $this->areas    = $areas;
+        $this->course = $course;
+        $this->cm = $cm;
+        $this->areas = $areas;
         $this->filearea = $filearea;
     }
 
@@ -69,10 +67,10 @@ class mod_mediagallery_file_info extends file_info {
     public function get_params() {
         return array('contextid' => $this->context->id,
                      'component' => 'mod_mediagallery',
-                     'filearea'  => $this->filearea,
-                     'itemid'    => null,
-                     'filepath'  => null,
-                     'filename'  => null);
+                     'filearea' => $this->filearea,
+                     'itemid' => null,
+                     'filepath' => null,
+                     'filename' => null);
     }
 
     /**
@@ -110,7 +108,7 @@ class mod_mediagallery_file_info extends file_info {
     /**
      * Help function to return files matching extensions or their count
      *
-     * @param string|array $extensions, either '*' or array of lowercase extensions, i.e. array('.gif','.jpg')
+     * @param string|array $extensions either '*' or array of lowercase extensions, i.e. array('.gif','.jpg')
      * @param bool|int $countonly if false returns the children, if an int returns just the
      *    count of children but stops counting when $countonly number of children is reached
      * @param bool $returnemptyfolders if true returns items that don't have matching files inside
@@ -142,7 +140,7 @@ class mod_mediagallery_file_info extends file_info {
      * Returns list of children which are either files matching the specified extensions
      * or folders that contain at least one such file.
      *
-     * @param string|array $extensions, either '*' or array of lowercase extensions, i.e. array('.gif','.jpg')
+     * @param string|array $extensions either '*' or array of lowercase extensions, i.e. array('.gif','.jpg')
      * @return array of file_info instances
      */
     public function get_non_empty_children($extensions = '*') {
@@ -153,7 +151,7 @@ class mod_mediagallery_file_info extends file_info {
      * Returns the number of children which are either files matching the specified extensions
      * or folders containing at least one such file.
      *
-     * @param string|array $extensions, for example '*' or array('.gif','.jpg')
+     * @param string|array $extensions for example '*' or array('.gif','.jpg')
      * @param int $limit stop counting after at least $limit non-empty children are found
      * @return int
      */

--- a/classes/file_info_area_gallery.php
+++ b/classes/file_info_area_gallery.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * File browsing support class.
  *
@@ -65,7 +63,7 @@ class mod_mediagallery_file_info_area_gallery extends file_info_stored {
      * Returns list of children which are either files matching the specified extensions
      * or folders that contain at least one such file.
      *
-     * @param string|array $extensions, either '*' or array of lowercase extensions, i.e. array('.gif','.jpg')
+     * @param string|array $extensions either '*' or array of lowercase extensions, i.e. array('.gif','.jpg')
      * @return array of file_info instances
      */
     public function get_non_empty_children($extensions = '*') {

--- a/classes/gallery.php
+++ b/classes/gallery.php
@@ -20,6 +20,19 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__).'/../locallib.php');
 
+/**
+ * Gallery
+ *
+ * @property-read string $instanceid
+ * @property-read string $name
+ * @property-read string $galleryfocus
+ * @property-read string $galleryview
+ * @property-read string $gridrows
+ * @property-read string $gridcolumns
+ * @property-read string $thumbnail
+ * @property-read string $mode
+ * @property-read string $contributable
+ */
 class gallery extends base {
 
     const VIEW_CAROUSEL = 0;

--- a/classes/gallery.php
+++ b/classes/gallery.php
@@ -135,7 +135,9 @@ class gallery extends base {
     }
 
     /**
-     * @param $list array List of item id's to download. Empty array means all files.
+     * Download items
+     *
+     * @param array $list List of item id's to download. Empty array means all files.
      * @return void
      */
     public function download_items(array $list = array()) {
@@ -417,8 +419,8 @@ class gallery extends base {
 
     /**
      * Determines if a given user can edit this gallery.
-     * @param $userid int The user to check can edit. If null then the current user is checked.
-     * @param $ownercheck bool Used to exclude readonly and submission checks to see if user is owner of the gallery.
+     * @param int $userid The user to check can edit. If null then the current user is checked.
+     * @param bool $ownercheck Used to exclude readonly and submission checks to see if user is owner of the gallery.
      */
     public function user_can_edit($userid = null, $ownercheck = false) {
         global $USER;

--- a/classes/imagehelper.php
+++ b/classes/imagehelper.php
@@ -16,8 +16,6 @@
 
 namespace mod_mediagallery;
 
-defined('MOODLE_INTERNAL') || die();
-
 class imagehelper {
 
     /**
@@ -25,8 +23,6 @@ class imagehelper {
      * We need to check before loading it, otherwise we get a fatal error.
      *
      * @param string $path Path to the file.
-     * @static
-     * @access public
      * @return bool true if there's enough memory to load the image, false otherwise.
      */
     public static function memory_check($path) {

--- a/classes/item.php
+++ b/classes/item.php
@@ -16,6 +16,14 @@
 
 namespace mod_mediagallery;
 
+/**
+ * Item
+ *
+ * @property-read string $galleryid
+ * @property-read string $caption
+ * @property-read string $externalurl
+ * @property-read string $processing_status
+ */
 class item extends base {
 
     protected $context;

--- a/classes/item.php
+++ b/classes/item.php
@@ -16,8 +16,6 @@
 
 namespace mod_mediagallery;
 
-defined('MOODLE_INTERNAL') || die();
-
 class item extends base {
 
     protected $context;
@@ -25,9 +23,7 @@ class item extends base {
     static protected $table = 'mediagallery_item';
     protected $tags = [];
 
-    /**
-     * Related stored files.
-     */
+    // Related stored files.
     protected $file = null;
     protected $lowres = null;
     protected $thumbnail = null;
@@ -73,22 +69,22 @@ class item extends base {
         $fs = get_file_storage();
         if ($file = $this->get_file()) { // Item.
             $fileinfo = array(
-                'contextid'     => $newitem->get_context()->id,
-                'itemid'        => $newitem->id,
+                'contextid' => $newitem->get_context()->id,
+                'itemid' => $newitem->id,
             );
             $fs->create_file_from_storedfile($fileinfo, $file);
         }
         if ($file = $this->get_file(true)) { // Thumbnail.
             $fileinfo = array(
-                'contextid'     => $newitem->get_context()->id,
-                'itemid'        => $newitem->id,
+                'contextid' => $newitem->get_context()->id,
+                'itemid' => $newitem->id,
             );
             $fs->create_file_from_storedfile($fileinfo, $file);
         }
         if ($file = $this->get_stored_file_by_type('lowres')) { // Low res version of full image.
             $fileinfo = array(
-                'contextid'     => $newitem->get_context()->id,
-                'itemid'        => $newitem->id,
+                'contextid' => $newitem->get_context()->id,
+                'itemid' => $newitem->id,
             );
             $fs->create_file_from_storedfile($fileinfo, $file);
         }
@@ -182,12 +178,12 @@ class item extends base {
 
             // Copy the file into the correct area.
             $fileinfo = array(
-                'contextid'     => $context->id,
-                'component'     => 'mod_mediagallery',
-                'filearea'      => 'item',
-                'itemid'        => $item->id,
-                'filepath'      => '/',
-                'filename'      => $filename
+                'contextid' => $context->id,
+                'component' => 'mod_mediagallery',
+                'filearea' => 'item',
+                'itemid' => $item->id,
+                'filepath' => '/',
+                'filename' => $filename
             );
             if (!$fs->get_file($context->id, 'mod_mediagallery', 'item', $item->id, '/', $filename)) {
                 $storedfile = $fs->create_file_from_storedfile($fileinfo, $storedfile);
@@ -201,6 +197,9 @@ class item extends base {
 
     /**
      * Delete the item and everything related to it.
+     *
+     * @param array $options
+     * @return bool
      */
     public function delete($options = array()) {
         global $DB;
@@ -294,7 +293,7 @@ class item extends base {
 
         ob_start();
         if (!$resized = $this->get_image_resized($originalfile, $w, $h, 0, 0, $type != 'lowres')) {
-            // File is smaller than lowres, so don't bother.'
+            // File is smaller than lowres, so don't bother.
             return false;
         }
         imagepng($resized);
@@ -460,7 +459,8 @@ class item extends base {
             if (!empty($this->objectid)) {
                 $embed = $this->get_box_url();
             } else if ($file = $this->get_file()) {
-                $embed = \moodle_url::make_pluginfile_url($this->get_context()->id, 'mod_mediagallery', 'item', $this->record->id, '/', $file->get_filename());
+                $embed = \moodle_url::make_pluginfile_url($this->get_context()->id, 'mod_mediagallery', 'item', $this->record->id,
+                                                        '/', $file->get_filename());
             }
         }
         return $embed;
@@ -628,7 +628,8 @@ class item extends base {
             // If its not an image, we want to display a moodle filetype icon, so we need to use the item path.
             $type = 'item';
         }
-        $path = \moodle_url::make_pluginfile_url($this->get_context()->id, 'mod_mediagallery', $type, $this->record->id, '/', $file->get_filename());
+        $path = \moodle_url::make_pluginfile_url($this->get_context()->id, 'mod_mediagallery', $type, $this->record->id, '/',
+                                                $file->get_filename());
         if ($preview && $type == 'item') {
             $path->param('preview', 'bigthumb');
         }
@@ -687,7 +688,8 @@ class item extends base {
             // If its not an image, we want to display a moodle filetype icon, so we need to use the item path.
             $urltype = 'item';
         }
-        $path = \moodle_url::make_pluginfile_url($this->get_context()->id, 'mod_mediagallery', $urltype, $this->record->id, '/', $file->get_filename());
+        $path = \moodle_url::make_pluginfile_url($this->get_context()->id, 'mod_mediagallery', $urltype, $this->record->id, '/',
+                                                $file->get_filename());
 
         // For audio/video files, this has moodle display a filetype icon.
         if ($type == 'thumbnail' && $urltype == 'item' && !$isimagetype) {

--- a/classes/mcsearch.php
+++ b/classes/mcsearch.php
@@ -55,7 +55,7 @@ class mcsearch {
         $search = array();
         $searchsql = "";
         if ($this->params['search']) {
-             $search = array(
+            $search = array(
                 $DB->sql_like('i.caption', '?', false, false),
                 $DB->sql_like($fullname, '?', false, false),
                 $DB->sql_like('u.username', '?', false, false),
@@ -153,7 +153,6 @@ class mcsearch {
      * Get the group names of all groups the users shown are in.
      *
      * @param array $userids
-     * @access public
      * @return array
      */
     public function get_groups_for_users($userids) {
@@ -181,7 +180,6 @@ class mcsearch {
      * Get the role names of all roles the users shown have.
      *
      * @param array $userids
-     * @access public
      * @return array
      */
     public function get_roles_for_users($userids) {
@@ -212,7 +210,6 @@ class mcsearch {
     /**
      * Trigger a download of a csv export of the search results.
      *
-     * @access public
      * @return void
      */
     public function download_csv() {

--- a/classes/output/collection/renderable.php
+++ b/classes/output/collection/renderable.php
@@ -16,8 +16,6 @@
 
 namespace mod_mediagallery\output\collection;
 
-defined('MOODLE_INTERNAL') || die();
-
 class renderable implements \renderable {
 
     public $collection;

--- a/classes/output/gallery/renderable.php
+++ b/classes/output/gallery/renderable.php
@@ -16,8 +16,6 @@
 
 namespace mod_mediagallery\output\gallery;
 
-defined('MOODLE_INTERNAL') || die();
-
 class renderable implements \renderable {
     const MEDIASIZE_SM = 0;
     const MEDIASIZE_MD = 1;

--- a/classes/output/searchresults/renderable.php
+++ b/classes/output/searchresults/renderable.php
@@ -16,8 +16,6 @@
 
 namespace mod_mediagallery\output\searchresults;
 
-defined('MOODLE_INTERNAL') || die();
-
 class renderable implements \renderable {
 
     public $results = array();

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -33,8 +33,6 @@ use core_privacy\local\request\transform;
 use core_privacy\local\request\userlist;
 use core_privacy\local\request\writer;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Implementation of the privacy subsystem plugin provider for the mediagallery activity module.
  *
@@ -142,9 +140,9 @@ class provider implements
 
         $params = [
             'contextlevel' => CONTEXT_MODULE,
-            'userid1'      => $userid,
-            'userid2'      => $userid,
-            'userid3'      => $userid,
+            'userid1' => $userid,
+            'userid2' => $userid,
+            'userid3' => $userid,
         ];
         $contextlist = new contextlist();
         $contextlist->add_from_sql($sql, $params);
@@ -226,7 +224,7 @@ class provider implements
         $params = ['userid1' => $userid, 'userid2' => $userid, 'userid3' => $userid] + $collparams;
         $galleries = $DB->get_recordset_sql($sql, $params);
 
-        foreach($galleries as $gallery) {
+        foreach ($galleries as $gallery) {
             $context = \context::instance_by_id($mappings[$gallery->instanceid]);
 
             $gallerydata = (object) [
@@ -238,7 +236,8 @@ class provider implements
             writer::with_context($context)
                 ->export_data($galleryarea, $gallerydata);
 
-            \core_tag\privacy\provider::export_item_tags($userid, $context, $galleryarea, 'mod_mediagallery', 'gallery', $gallery->id);
+            \core_tag\privacy\provider::export_item_tags($userid, $context, $galleryarea, 'mod_mediagallery', 'gallery',
+                                                        $gallery->id);
         }
         $galleries->close();
     }
@@ -272,7 +271,7 @@ class provider implements
      *
      * @param   int         $userid The userid of the user whose data is to be exported.
      * @param   \context    $context The instance of the mediagallery context.
-     * @param   \stdClass   $discussion The gallery whose data is being exported.
+     * @param   \stdClass   $gallery The gallery whose data is being exported.
      */
     protected static function export_all_items_in_gallery($userid, $context, $gallery) {
         global $DB;
@@ -392,7 +391,7 @@ class provider implements
                       FROM {mediagallery_item} i
                       WHERE userid = :userid AND galleryid IN (
                         SELECT id
-                        FROM {mediagallery_gallery} 
+                        FROM {mediagallery_gallery}
                         WHERE instanceid = :instanceid
                       )";
         foreach ($contextlist->get_contexts() as $context) {
@@ -428,14 +427,16 @@ class provider implements
     }
 
     public static function export_user_preferences(int $userid) {
-        $pref = get_user_preferences('mod_mediagallery_mediasize', \mod_mediagallery\output\gallery\renderable::MEDIASIZE_MD, $userid);
+        $pref = get_user_preferences('mod_mediagallery_mediasize', \mod_mediagallery\output\gallery\renderable::MEDIASIZE_MD,
+                                    $userid);
         $string = 'mediasizemd';
         if ($pref == \mod_mediagallery\output\gallery\renderable::MEDIASIZE_SM) {
-          $string = 'mediasizesm';
+            $string = 'mediasizesm';
         } else if ($pref == \mod_mediagallery\output\gallery\renderable::MEDIASIZE_LG) {
-          $string = 'mediasizelg';
+            $string = 'mediasizelg';
         }
-        writer::export_user_preference('mod_mediagallery', 'mod_mediagallery_mediasize', $pref, get_string($string, 'mod_mediagallery'));
+        writer::export_user_preference('mod_mediagallery', 'mod_mediagallery_mediasize', $pref,
+                                        get_string($string, 'mod_mediagallery'));
     }
 
     /**
@@ -452,7 +453,7 @@ class provider implements
         }
 
         $params = [
-            'instanceid'    => $context->instanceid,
+            'instanceid' => $context->instanceid,
         ];
 
         $collectionsql = "SELECT userid

--- a/classes/privacy/subcontext_info.php
+++ b/classes/privacy/subcontext_info.php
@@ -29,8 +29,6 @@ use \core_privacy\request\approved_contextlist;
 use \core_privacy\request\writer;
 use \core_privacy\metadata\item_collection;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Subcontext helper trait.
  *
@@ -67,7 +65,6 @@ trait subcontext_info {
     /**
      * Get the item part of the subcontext.
      *
-     * @param   \stdClass   $gallery The gallery
      * @return  array
      */
     protected static function get_item_area() : Array {

--- a/classes/privacy/subcontext_info.php
+++ b/classes/privacy/subcontext_info.php
@@ -42,7 +42,7 @@ trait subcontext_info {
      * @param   \stdClass   $gallery The gallery
      * @return  array
      */
-    protected static function get_gallery_area(\stdClass $gallery) : Array {
+    protected static function get_gallery_area(\stdClass $gallery) : array {
         $pathparts = [];
         if (!empty($discussion->groupname)) {
             $pathparts[] = get_string('groups');

--- a/classes/privacy/subcontext_info.php
+++ b/classes/privacy/subcontext_info.php
@@ -67,7 +67,7 @@ trait subcontext_info {
      *
      * @return  array
      */
-    protected static function get_item_area() : Array {
+    protected static function get_item_area() : array {
         $pathparts = [
             get_string('areaitem', 'mod_mediagallery'),
         ];

--- a/classes/quickform/limitedurl.php
+++ b/classes/quickform/limitedurl.php
@@ -23,17 +23,17 @@ class MoodleQuickForm_limitedurl extends MoodleQuickForm_url {
     public $_helpbutton = '';
 
     // If true label will be hidden.
-    public $_hiddenLabel = false;
+    public $_hiddenLabel = false; // phpcs:ignore moodle.NamingConventions.ValidVariableName.MemberNameUnderscore
 
     /**
      * Returns HTML for this form element.
      *
      * @return string
      */
-    public function toHtml() {
+    public function toHtml() { // phpcs:ignore moodle.NamingConventions.ValidFunctionName.LowercaseMethod
         global $PAGE, $OUTPUT;
 
-        $id     = $this->_attributes['id'];
+        $id = $this->_attributes['id'];
         $elname = $this->_attributes['name'];
 
         if ($this->_hiddenLabel) {

--- a/classes/quickform/limitedurl.php
+++ b/classes/quickform/limitedurl.php
@@ -41,7 +41,7 @@ class MoodleQuickForm_limitedurl extends MoodleQuickForm_url {
             $str = '<label class="accesshide" for="'.$this->getAttribute('id').'" >'.
                         $this->getLabel().'</label>'.parent::toHtml();
         } else {
-            $str = HTML_QuickForm_Text::toHtml();
+            $str = HTML_QuickForm_text::toHtml();
         }
         if (empty($this->_options['usefilepicker'])) {
             return $str;

--- a/classes/quickform/uploader.php
+++ b/classes/quickform/uploader.php
@@ -24,8 +24,8 @@ class MoodleQuickForm_uploader extends MoodleQuickForm_filepicker {
 
     public $repo = '';
 
-    public function __construct($elementName = null, $elementLabel = null, $attributes = null, $options = null) {
-        parent::__construct($elementName, $elementLabel, $attributes, $options);
+    public function __construct($elementname = null, $elementlabel = null, $attributes = null, $options = null) {
+        parent::__construct($elementname, $elementlabel, $attributes, $options);
         $this->repo = $options['repo'];
     }
 
@@ -33,7 +33,7 @@ class MoodleQuickForm_uploader extends MoodleQuickForm_filepicker {
      * Legacy style constructor, for BC.
      * @deprecated since 2.9, use MoodleQuickForm_uploader::__construct instead
      */
-    public function MoodleQuickForm_uploader() {
+    public function MoodleQuickForm_uploader() { // phpcs:ignore moodle.NamingConventions.ValidFunctionName.LowercaseMethod
         $msg = 'Legacy constructor called, please update your code to call php5 constructor!';
         if (function_exists('debugging')) {
             debugging($msg, DEBUG_DEVELOPER);
@@ -44,9 +44,9 @@ class MoodleQuickForm_uploader extends MoodleQuickForm_filepicker {
         call_user_func_array('self::__construct', $args);
     }
 
-    public function toHtml() {
+    public function toHtml() { // phpcs:ignore moodle.NamingConventions.ValidFunctionName.LowercaseMethod
         global $CFG, $COURSE, $USER, $PAGE, $OUTPUT;
-        $id     = $this->_attributes['id'];
+        $id = $this->_attributes['id'];
         $elname = $this->_attributes['name'];
 
         if ($this->_flagFrozen) {

--- a/classes/quickform/uploader_standard.php
+++ b/classes/quickform/uploader_standard.php
@@ -24,9 +24,9 @@ class MoodleQuickForm_uploader_standard extends MoodleQuickForm_filepicker {
 
     public $repo = '';
 
-    public function toHtml() {
+    public function toHtml() { // phpcs:ignore moodle.NamingConventions.ValidFunctionName.LowercaseMethod
         global $CFG, $COURSE, $USER, $PAGE, $OUTPUT;
-        $id     = $this->_attributes['id'];
+        $id = $this->_attributes['id'];
         $elname = $this->_attributes['name'];
 
         if ($this->_flagFrozen) {

--- a/classes/viewcontroller.php
+++ b/classes/viewcontroller.php
@@ -17,8 +17,6 @@
 
 namespace mod_mediagallery;
 
-defined('MOODLE_INTERNAL') || die();
-
 class viewcontroller {
 
     public $cm;
@@ -50,7 +48,6 @@ class viewcontroller {
      * Routes to a valid action.
      *
      * @param string $action
-     * @access public
      * @return string Rendered output for display.
      */
     public function display_action($action) {
@@ -158,7 +155,7 @@ class viewcontroller {
             $renderable = new output\gallery\renderable($gallery, $this->options['editing'], $this->options);
             $output .= $this->renderer->render_gallery($renderable);
         } else {
-            print_error('nopermissions', 'error', $this->pageurl, 'view gallery');
+            throw new \moodle_exception('nopermissions', 'error', $this->pageurl, 'view gallery');
         }
         return $output;
     }

--- a/db/install.php
+++ b/db/install.php
@@ -15,6 +15,8 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Post installation procedure
+ *
  * This file replaces the legacy STATEMENTS section in db/install.xml,
  * lib.php/modulename_install() post installation hook and partially defaults.php
  *
@@ -23,8 +25,6 @@
  * @author     Adam Olley <adam.olley@netspot.com.au>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Post installation procedure

--- a/db/log.php
+++ b/db/log.php
@@ -21,8 +21,7 @@
  * It is not really essential to know about it, but these logs were created as example
  * in the previous 1.9 NEWMODULE.
  *
- * @package    mod
- * @subpackage mediagallery
+ * @package    mod_mediagallery
  * @copyright  NetSpot Pty Ltd <your@email.adress>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -15,12 +15,12 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * mediagallery upgrade
+ *
  * @package    mod_mediagallery
  * @copyright  NetSpot Pty Ltd
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Execute mediagallery upgrade from the given old version

--- a/export.php
+++ b/export.php
@@ -15,6 +15,8 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Page to export Media collections
+ *
  * @package    mod_mediagallery
  * @copyright  NetSpot Pty Ltd
  * @author     Adam Olley <adam.olley@netspot.com.au>

--- a/gallery.php
+++ b/gallery.php
@@ -32,7 +32,7 @@ $m = optional_param('m', 0, PARAM_INT); // The mediagallery id.
 $g = optional_param('g', $id, PARAM_INT); // A gallery id.
 
 if (!$m && !$g) {
-    print_error('missingparameter');
+    throw new \moodle_exception('missingparameter');
 }
 
 $gallery = false;
@@ -106,7 +106,7 @@ if ($mform->is_cancelled()) {
     redirect(new moodle_url('/mod/mediagallery/view.php', array('g' => $gallery->id, 'editing' => 1)));
 } else if ($gallery) {
     if (!$gallery->user_can_edit()) {
-        print_error('nopermissions', 'error', $pageurl, 'edit gallery');
+        throw new \moodle_exception('nopermissions', 'error', $pageurl, 'edit gallery');
     }
     $data = $gallery->get_record();
     $data->tags = core_tag_tag::get_item_tags_array('mod_mediagallery', 'mediagallery_gallery', $gallery->id);

--- a/gallery_form.php
+++ b/gallery_form.php
@@ -212,7 +212,7 @@ class mod_mediagallery_gallery_form extends moodleform {
     /**
      * Set the forms data.
      *
-     * @param array $data
+     * @param stdClass|array $data
      * @return void
      */
     public function set_data($data) {

--- a/gallery_form.php
+++ b/gallery_form.php
@@ -105,7 +105,8 @@ class mod_mediagallery_gallery_form extends moodleform {
             $mform->addHelpButton('contributable', 'contributable', 'mediagallery');
         }
 
-        $mform->addElement('tags', 'tags', get_string('tags'), ['itemtype' => 'mediagallery_gallery', 'component' => 'mod_mediagallery']);
+        $mform->addElement('tags', 'tags', get_string('tags'),
+                            ['itemtype' => 'mediagallery_gallery', 'component' => 'mod_mediagallery']);
 
         if ($lockfields) {
             $mform->hardFreeze('name');

--- a/index.php
+++ b/index.php
@@ -52,13 +52,13 @@ if (! $mediagallerys = get_all_instances_in_course('mediagallery', $course)) {
 
 $table = new html_table();
 if ($course->format == 'weeks') {
-    $table->head  = array(get_string('week'), get_string('name'));
+    $table->head = array(get_string('week'), get_string('name'));
     $table->align = array('center', 'left');
 } else if ($course->format == 'topics') {
-    $table->head  = array(get_string('topic'), get_string('name'));
+    $table->head = array(get_string('topic'), get_string('name'));
     $table->align = array('center', 'left', 'left', 'left');
 } else {
-    $table->head  = array(get_string('name'));
+    $table->head = array(get_string('name'));
     $table->align = array('left', 'left', 'left');
 }
 
@@ -74,7 +74,7 @@ foreach ($mediagallerys as $mediagallery) {
             format_string($mediagallery->name, true));
     }
 
-    if ($course->format == 'weeks' or $course->format == 'topics') {
+    if ($course->format == 'weeks' || $course->format == 'topics') {
         $table->data[] = array($mediagallery->section, $link);
     } else {
         $table->data[] = array($link);

--- a/item.php
+++ b/item.php
@@ -34,7 +34,7 @@ $i = optional_param('i', 0, PARAM_INT); // An item id.
 $bulk = optional_param('bulk', false, PARAM_BOOL);
 
 if (!$g && !$i) {
-    print_error('missingparameter');
+    throw new \moodle_exception('missingparameter');
 }
 
 
@@ -43,7 +43,7 @@ if ($i) {
     $item = new \mod_mediagallery\item($i);
     $g = $item->galleryid;
     if (!$item->user_can_edit()) {
-        print_error('nopermissions', 'error', null, 'edit item');
+        throw new \moodle_exception('nopermissions', 'error', null, 'edit item');
     }
 }
 
@@ -56,7 +56,7 @@ require_login($course, true, $cm);
 $context = context_module::instance($cm->id);
 $pageurl = new moodle_url('/mod/mediagallery/item.php', array('g' => $gallery->id));
 if (!$gallery->user_can_contribute()) {
-    print_error('nopermissions', 'error', $pageurl, 'edit gallery');
+    throw new \moodle_exception('nopermissions', 'error', $pageurl, 'edit gallery');
 }
 
 $PAGE->set_url($pageurl);
@@ -165,7 +165,7 @@ if ($mform->is_cancelled()) {
 
 $maxitems = $mediagallery->maxitems;
 if (!$item && $maxitems != 0 && count($gallery->get_items()) >= $maxitems) {
-    print_error('errortoomanyitems', 'mediagallery', '', $maxitems);
+    throw new \moodle_exception('errortoomanyitems', 'mediagallery', '', $maxitems);
 }
 
 echo $OUTPUT->header();

--- a/item_bulk_form.php
+++ b/item_bulk_form.php
@@ -73,8 +73,8 @@ class mod_mediagallery_item_bulk_form extends moodleform {
     /**
      * Validate the user input.
      *
-     * @param mixed $data The submitted data.
-     * @param mixed $files The submitted files.
+     * @param array $data The submitted data.
+     * @param array $files The submitted files.
      * @return array A list of errors, if any.
      */
     public function validation($data, $files) {

--- a/item_form.php
+++ b/item_form.php
@@ -146,8 +146,8 @@ class mod_mediagallery_item_form extends moodleform {
     /**
      * Validate user input.
      *
-     * @param mixed $data The submitted form data.
-     * @param mixed $files The submitted files.
+     * @param array $data The submitted form data.
+     * @param array $files The submitted files.
      * @return array List of errors, if any.
      */
     public function validation($data, $files) {

--- a/item_form.php
+++ b/item_form.php
@@ -105,7 +105,8 @@ class mod_mediagallery_item_form extends moodleform {
 
         $lockfields = $item && !$item->user_can_edit() ? true : false;
 
-        $mform->addElement('tags', 'tags', get_string('tags'), ['itemtype' => 'mediagallery_item', 'component' => 'mod_mediagallery']);
+        $mform->addElement('tags', 'tags', get_string('tags'),
+                            ['itemtype' => 'mediagallery_item', 'component' => 'mod_mediagallery']);
 
         if ($lockfields) {
             $mform->hardFreeze('caption');
@@ -159,7 +160,7 @@ class mod_mediagallery_item_form extends moodleform {
             $errors['filecheck'] = get_string('required');
         } else if (!empty($url) && !preg_match('|^/|', $url)) {
             // Links relative to server root are ok - no validation necessary.
-            if (preg_match('|^[a-z]+://|i', $url) or preg_match('|^https?:|i', $url) or preg_match('|^ftp:|i', $url)) {
+            if (preg_match('|^[a-z]+://|i', $url) || preg_match('|^https?:|i', $url) || preg_match('|^ftp:|i', $url)) {
                 // Normal URL.
                 if (!mediagallery_appears_valid_url($url)) {
                     $errors['externalurl'] = get_string('invalidurl', 'url');

--- a/lib.php
+++ b/lib.php
@@ -207,7 +207,7 @@ function mediagallery_user_outline($course, $user, $mod, $mediagallery) {
  * @param stdClass $user the record of the user we are generating report for
  * @param cm_info $mod course module info
  * @param stdClass $mediagallery the module instance record
- * @return void, is supposed to echp directly
+ * @return void is supposed to echp directly
  */
 function mediagallery_user_complete($course, $user, $mod, $mediagallery) {
 }

--- a/lib.php
+++ b/lib.php
@@ -23,8 +23,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Returns the information on whether the module supports a feature
  *
@@ -233,7 +231,7 @@ function mediagallery_print_recent_activity($course, $viewfullnames, $timestart)
  *
  * This callback function is supposed to populate the passed array with
  * custom activity records. These records are then rendered into HTML via
- * {@link mediagallery_print_recent_mod_activity()}.
+ * {@see mediagallery_print_recent_mod_activity()}.
  *
  * @param array $activities sequentially indexed array of objects with the 'cmid' property
  * @param int $index the index in the $activities to use for the next record
@@ -345,7 +343,7 @@ function mediagallery_update_grades(stdClass $mediagallery, $userid = 0) {
  * Returns the lists of all browsable file areas within the given module context
  *
  * The file area 'intro' for the activity introduction field is added automatically
- * by {@link file_browser::get_file_info_context_module()}
+ * by {@see \file_browser::get_file_info_context_module()}
  *
  * @param stdClass $course
  * @param stdClass $cm
@@ -407,7 +405,7 @@ function mediagallery_get_file_info($browser, $areas, $course, $cm, $context, $f
     $filepath = is_null($filepath) ? '/' : $filepath;
     $filename = is_null($filename) ? '.' : $filename;
     if (!$storedfile = $fs->get_file($context->id, 'mod_mediagallery', $filearea, $itemid, $filepath, $filename)) {
-        if ($filepath === '/' and $filename === '.') {
+        if ($filepath === '/' && $filename === '.') {
             $storedfile = new virtual_root_file($context->id, 'mod_mediagallery', 'collection', 0);
         } else {
             return null;
@@ -450,7 +448,7 @@ function mediagallery_pluginfile($course, $cm, $context, $filearea, array $args,
     $fs = get_file_storage();
     $relativepath = implode('/', $args);
     $fullpath = "/$context->id/mod_mediagallery/$filearea/$itemid/$relativepath";
-    if (!$file = $fs->get_file_by_hash(sha1($fullpath)) or $file->is_directory()) {
+    if (!($file = $fs->get_file_by_hash(sha1($fullpath))) || $file->is_directory()) {
         return false;
     }
 

--- a/locallib.php
+++ b/locallib.php
@@ -270,7 +270,7 @@ function mediagallery_generate_search_sql($parsetree) {
     static $p = 0;
 
     if ($DB->sql_regex_supported()) {
-        $regexp    = $DB->sql_regex(true);
+        $regexp = $DB->sql_regex(true);
         $notregexp = $DB->sql_regex(false);
     }
 
@@ -545,7 +545,8 @@ function mod_mediagallery_get_tagged_galleries($tag, $exclusivemode = false, $fr
 
     $totalpages = $page + 1;
 
-    $builder = new core_tag_index_builder('mod_mediagallery', 'mediagallery_gallery', $query, $params, $page * $perpage, $perpage + 1);
+    $builder = new core_tag_index_builder('mod_mediagallery', 'mediagallery_gallery', $query, $params, $page * $perpage,
+                                        $perpage + 1);
 
     while ($item = $builder->has_item_that_needs_access_check()) {
         context_helper::preload_from_record($item);

--- a/locallib.php
+++ b/locallib.php
@@ -344,7 +344,7 @@ function mediagallery_generate_search_sql($parsetree) {
 /**
  * Add metainfo fields to a moodleform.
  *
- * @param moodleform $mform
+ * @param MoodleQuickForm $mform
  * @return void
  */
 function mediagallery_add_metainfo_fields(&$mform) {

--- a/mod_form.php
+++ b/mod_form.php
@@ -83,7 +83,8 @@ class mod_mediagallery_mod_form extends moodleform_mod {
         $opts = array(
             'standard' => get_string('modestandard', 'mod_mediagallery'),
         );
-        if (!empty($config->disablestandardgallery) && (empty($this->_instance) || $this->current->mode == 'thebox') && count($opts) > 1) {
+        if (!empty($config->disablestandardgallery) && (empty($this->_instance) || $this->current->mode == 'thebox')
+                && count($opts) > 1) {
             unset($opts['standard']);
         }
 

--- a/renderer.php
+++ b/renderer.php
@@ -230,7 +230,7 @@ class mod_mediagallery_renderer extends plugin_renderer_base {
      * Render the action icons for a gallery.
      *
      * @param \mod_mediagallery\gallery $gallery
-     * @return string
+     * @return string[]
      */
     public function gallery_list_item_actions($gallery) {
         $actions = array();
@@ -325,7 +325,7 @@ class mod_mediagallery_renderer extends plugin_renderer_base {
      * Render a gallery.
      *
      * @param rengallery $renderable Gallery renderable details.
-     * @return void
+     * @return string
      */
     public function render_gallery(rengallery $renderable) {
         $gallery = $renderable->gallery;
@@ -1017,7 +1017,7 @@ class mod_mediagallery_standard_renderer extends mod_mediagallery_renderer {
      * Render the action icons for a gallery.
      *
      * @param \mod_mediagallery\gallery $gallery
-     * @return string
+     * @return string[]
      */
     public function gallery_list_item_actions($gallery) {
         $actions = parent::gallery_list_item_actions($gallery);

--- a/renderer.php
+++ b/renderer.php
@@ -990,7 +990,7 @@ class mod_mediagallery_renderer extends plugin_renderer_base {
         $gb = ' ' . get_string('sizegb');
         $mb = ' ' . get_string('sizemb');
         $kb = ' ' . get_string('sizekb');
-        $b  = ' ' . get_string('sizeb');
+        $b = ' ' . get_string('sizeb');
         if ($size >= 1073741824) {
             $size = number_format(round($size / 1073741824 * 10, 1) / 10, 1) . $gb;
         } else if ($size >= 1048576) {

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@
 }
 
 .path-mod-mediagallery .gallery_list .row {
-    margin-left: 0px;
+    margin-left: 0;
     margin-bottom: 10px;
 }
 
@@ -59,8 +59,8 @@
     overflow: hidden;
     white-space: nowrap;
     width: 100px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .path-mod-mediagallery .gallery_list_item .title .tooltiptext,
@@ -75,8 +75,6 @@
 
     position: absolute;
     z-index: 1;
-
-    width: 120px;
 }
 
 .path-mod-mediagallery .gallery_list_item .title:hover .tooltiptext,
@@ -97,7 +95,7 @@
 
 .path-mod-mediagallery .gallery_items .controls .moodle-actionmenu,
 .path-mod-mediagallery .gallery_list_item .controls .moodle-actionmenu {
-    display: inline-block !important;
+    display: inline-block !important;  /* stylelint-disable-line declaration-no-important */
 }
 
 .path-mod-mediagallery .gallery_items .controls .icon,
@@ -195,7 +193,7 @@
 }
 
 .path-mod-mediagallery .menumediasize {
-    margin-bottom: 0px;
+    margin-bottom: 0;
 }
 
 .path-mod-mediagallery .moralrights {
@@ -203,11 +201,11 @@
     height: 30px;
     width: 30px;
     text-align: center;
-    background-color: #00CB00;
+    background-color: #00cb00;
 }
 
 .path-mod-mediagallery .moralrights.no {
-    background-color: #CB0000;
+    background-color: #cb0000;
 }
 .path-mod-mediagallery .moralrights img {
     margin-top: 6px;
@@ -238,7 +236,7 @@
 }
 
 .path-mod-mediagallery .lb-dataContainer {
-    background: #FFF;
+    background: #fff;
     min-width: 400px;
     padding-top: 7px;
 }
@@ -336,11 +334,11 @@
     position: relative;
     border: 10px solid #fff;
     -webkit-border-radius: 5px;
-       -moz-border-radius: 5px;
-            border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
     -webkit-box-shadow: 0 0 2px #999;
-       -moz-box-shadow: 0 0 2px #999;
-            box-shadow: 0 0 2px #999;
+    -moz-box-shadow: 0 0 2px #999;
+    box-shadow: 0 0 2px #999;
 }
 
 
@@ -400,7 +398,7 @@
     width: 30px;
     height: 30px;
     text-align: center;
-    background: #4E443C;
+    background: #4e443c;
     color: #fff;
     text-decoration: none;
     text-shadow: 0 0 1px #000;
@@ -408,9 +406,9 @@
     -webkit-border-radius: 30px;
     -moz-border-radius: 30px;
     border-radius: 30px;
-    -webkit-box-shadow: 0 0 4px #F0EFE7;
-    -moz-box-shadow: 0 0 4px #F0EFE7;
-    box-shadow: 0 0 4px #F0EFE7;
+    -webkit-box-shadow: 0 0 4px #f0efe7;
+    -moz-box-shadow: 0 0 4px #f0efe7;
+    box-shadow: 0 0 4px #f0efe7;
 }
 
 .jcarousel-control-prev {
@@ -451,26 +449,26 @@
     line-height: 10px;
 
     background: #fff;
-    color: #4E443C;
+    color: #4e443c;
     border-radius: 10px;
     text-indent: -9999px;
 
     margin-right: 7px;
 
 
-    -webkit-box-shadow: 0 0 2px #4E443C;
-    -moz-box-shadow: 0 0 2px #4E443C;
-    box-shadow: 0 0 2px #4E443C;
+    -webkit-box-shadow: 0 0 2px #4e443c;
+    -moz-box-shadow: 0 0 2px #4e443c;
+    box-shadow: 0 0 2px #4e443c;
 }
 
 .jcarousel-pagination a.active {
-    background: #4E443C;
+    background: #4e443c;
     color: #fff;
     opacity: 1;
 
-    -webkit-box-shadow: 0 0 2px #F0EFE7;
-    -moz-box-shadow: 0 0 2px #F0EFE7;
-    box-shadow: 0 0 2px #F0EFE7;
+    -webkit-box-shadow: 0 0 2px #f0efe7;
+    -moz-box-shadow: 0 0 2px #f0efe7;
+    box-shadow: 0 0 2px #f0efe7;
 }
 
 div.sample_target_wrapper {
@@ -530,7 +528,7 @@ body.mediaboxactive .gallery .mediaplugin object {
 
 #mediabox-content .mediaplugin object,
 .gallery .mediaplugin object {
-    margin-left: 0 !important;
+    margin-left: 0 !important;  /* stylelint-disable-line declaration-no-important */
 }
 
 .gallery .mediafallbacklink {
@@ -544,7 +542,7 @@ body.mediaboxactive .gallery .mediaplugin object {
 
 #mediabox-content .mediaplugin.audio object,
 .gallery .mediaplugin object {
-    width: 250px !important;
+    width: 250px !important;  /* stylelint-disable-line declaration-no-important */
 }
 
 #mediabox-content .mediaplugin.video.flow {
@@ -560,7 +558,7 @@ body.mediaboxactive .gallery .mediaplugin object {
     background-color: #222;
     overflow-x: hidden;
     overflow-y: auto;
-    color: #FFF;
+    color: #fff;
     padding-top: 30px;
 }
 
@@ -596,7 +594,6 @@ body.mediaboxactive .gallery .mediaplugin object {
 }
 
 
-
 #mediabox-navbar .navitem img {
     width: 58px;
 }
@@ -606,7 +603,7 @@ body.mediaboxactive .gallery .mediaplugin object {
 }
 
 #mediabox.sidebarhidden #mediabox-sidebar {
-    width: 0px;
+    width: 0;
 }
 
 #mediabox-metainfo,
@@ -705,10 +702,10 @@ body.mediaboxactive .gallery .mediaplugin object {
     float: left;
     border: 0;
     height: 1px;
-    background-image: -webkit-linear-gradient(left, rgba(0,0,0,0), rgba(255,255,255,0.75), rgba(0,0,0,0));
-    background-image:    -moz-linear-gradient(left, rgba(0,0,0,0), rgba(255,255,255,0.75), rgba(0,0,0,0));
-    background-image:     -ms-linear-gradient(left, rgba(0,0,0,0), rgba(255,255,255,0.75), rgba(0,0,0,0));
-    background-image:      -o-linear-gradient(left, rgba(0,0,0,0), rgba(255,255,255,0.75), rgba(0,0,0,0));
+    background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0), rgba(255, 255, 255, 0.75), rgba(0, 0, 0, 0));
+    background-image:    -moz-linear-gradient(left, rgba(0, 0, 0, 0), rgba(255, 255, 255, 0.75), rgba(0, 0, 0, 0));
+    background-image:     -ms-linear-gradient(left, rgba(0, 0, 0, 0), rgba(255, 255, 255, 0.75), rgba(0, 0, 0, 0));
+    background-image:      -o-linear-gradient(left, rgba(0, 0, 0, 0), rgba(255, 255, 255, 0.75), rgba(0, 0, 0, 0));
 }
 
 #page-mod-mediagallery-item .mform #id_general iframe {
@@ -718,7 +715,7 @@ body.mediaboxactive .gallery .mediaplugin object {
 }
 
 #page-mod-mediagallery-item .mform .femptylabel .felement.fstatic {
-    margin-left: 0px;
+    margin-left: 0;
 }
 
 .path-mod-mediagallery .deleteorremove {
@@ -733,7 +730,7 @@ body.mediaboxactive .gallery .mediaplugin object {
 
 .path-mod-mediagallery .actions.collection > span,
 .path-mod-mediagallery a.maction {
-    font-family: Lato,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 16px;
     font-weight: 400;
     -webkit-font-smoothing: subpixel-antialiased;
@@ -752,7 +749,7 @@ body.mediaboxactive .gallery .mediaplugin object {
 }
 
 .path-mod-mediagallery .controls {
-    font-family: Lato,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 15px;
     font-weight: 400;
     -webkit-font-smoothing: subpixel-antialiased;
@@ -807,10 +804,10 @@ body.mediaboxactive .gallery .mediaplugin object {
     border: 1px solid #e3e3e3;
     border-color: #e3e3e3;
     border-radius: 3px;
-    box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 
 .path-mod-mediagallery #mediabox-content .mediaplugin {
-    width: auto !important;
-    height: auto !important;
+    width: auto !important; /* stylelint-disable-line declaration-no-important */
+    height: auto !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -37,7 +37,7 @@ namespace mod_mediagallery;
 class base_test extends \advanced_testcase {
 
     /**
-     * @var stdClass Course object.
+     * @var \stdClass Course object.
      */
     protected $course;
 

--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -23,15 +23,18 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace mod_mediagallery;
 
 /**
  * Unit tests for basic module functionality.
  *
  * @copyright Copyright (c) 2017 Blackboard Inc.
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \mod_mediagallery\collection
+ * @covers    \mod_mediagallery\gallery
+ * @covers    \mod_mediagallery\item
  */
-class mod_mediagallery_base_testcase extends advanced_testcase {
+class base_test extends \advanced_testcase {
 
     /**
      * @var stdClass Course object.

--- a/tests/behat/add_mediagallery.feature
+++ b/tests/behat/add_mediagallery.feature
@@ -66,7 +66,7 @@ Feature: Add mediagallery activities and galleries
     Then I should not see "Gallery focus"
 
   Scenario: Student cannot add a gallery to an instructor collection
-   Given I log in as "student1"
-   And I am on "Course 1" course homepage
-   And I follow "Instructor collection"
-   Then I should not see "Add a gallery"
+    Given I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Instructor collection"
+    Then I should not see "Add a gallery"

--- a/tests/collection_test.php
+++ b/tests/collection_test.php
@@ -23,15 +23,16 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace mod_mediagallery;
 
 /**
  * Unit tests for the collection class.
  *
  * @copyright Copyright (c) 2017 Blackboard Inc.
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \mod_mediagallery\collection
  */
-class mod_mediagallery_collection_testcase extends advanced_testcase {
+class collection_test extends \advanced_testcase {
 
     /**
      * @var stdClass Course object.

--- a/tests/collection_test.php
+++ b/tests/collection_test.php
@@ -35,7 +35,7 @@ namespace mod_mediagallery;
 class collection_test extends \advanced_testcase {
 
     /**
-     * @var stdClass Course object.
+     * @var \stdClass Course object.
      */
     protected $course;
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -90,7 +90,7 @@ class mod_mediagallery_generator extends testing_module_generator {
     /**
      * Create a gallery object.
      *
-     * @param mixed $record An array or object defining a gallery.
+     * @param array|object $record An array or object defining a gallery.
      * @return \mod_mediagallery\gallery
      */
     public function create_gallery($record = null) {
@@ -125,7 +125,7 @@ class mod_mediagallery_generator extends testing_module_generator {
     /**
      * Create an item.
      *
-     * @param mixed $record An array or object defining a item.
+     * @param array|object $record An array or object defining a item.
      * @return \mod_mediagallery\item
      */
     public function create_item($record = null) {

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -23,8 +23,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * mediagallery module data generator class
  *
@@ -58,25 +56,25 @@ class mod_mediagallery_generator extends testing_module_generator {
         }
 
         $defaultsettings = array(
-            'name'               => get_string('pluginname', 'mediagallery').' '.$i,
-            'intro'              => 'Test mediagallery ' . $i,
-            'introformat'        => FORMAT_MOODLE,
-            'userid'             => 0,
-            'thumbnailsperpage'  => 0,
-            'thumbnailsperrow'   => 2,
+            'name' => get_string('pluginname', 'mediagallery').' '.$i,
+            'intro' => 'Test mediagallery ' . $i,
+            'introformat' => FORMAT_MOODLE,
+            'userid' => 0,
+            'thumbnailsperpage' => 0,
+            'thumbnailsperrow' => 2,
             'displayfullcaption' => 0,
-            'captionposition'    => 0,
-            'colltype'           => 'contributed',
-            'galleryfocus'       => 1,
+            'captionposition' => 0,
+            'colltype' => 'contributed',
+            'galleryfocus' => 1,
             'galleryviewoptions' => array('carousel' => 1),
-            'gridrows'           => 2,
-            'gridcolumns'        => 3,
-            'enforcedefauls'     => 0,
-            'readonlyfrom'       => 0,
-            'readonlyto'         => 0,
-            'mode'               => 'standard',
-            'contributable'      => 0,
-            'maxgalleries'       => 0,
+            'gridrows' => 2,
+            'gridcolumns' => 3,
+            'enforcedefauls' => 0,
+            'readonlyfrom' => 0,
+            'readonlyto' => 0,
+            'mode' => 'standard',
+            'contributable' => 0,
+            'maxgalleries' => 0,
         );
         $defaultsettings['gallerytypeoptions']['focus'] = 1;
 

--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -23,6 +23,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace mod_mediagallery;
+
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
 
@@ -41,8 +43,9 @@ require_once($CFG->dirroot . '/mod/mediagallery/lib.php');
  * @category   test
  * @author     Adam Olley <adam.olley@blackboard.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \mod_mediagallery\privacy\provider
  */
-class mod_mediagallery_privacy_testcase extends provider_testcase {
+class privacy_test extends provider_testcase {
 
     use \mod_mediagallery\privacy\subcontext_info;
 
@@ -104,22 +107,22 @@ class mod_mediagallery_privacy_testcase extends provider_testcase {
 
         $contextids = provider::get_contexts_for_userid($users[0]->id)->get_contextids();
         $this->assertCount(3, $contextids);
-        $this->assertTrue(in_array(context_module::instance($cm1a->cmid)->id, $contextids));
-        $this->assertTrue(in_array(context_module::instance($cm1b->cmid)->id, $contextids));
-        $this->assertTrue(in_array(context_module::instance($cm2a->cmid)->id, $contextids));
+        $this->assertTrue(in_array(\context_module::instance($cm1a->cmid)->id, $contextids));
+        $this->assertTrue(in_array(\context_module::instance($cm1b->cmid)->id, $contextids));
+        $this->assertTrue(in_array(\context_module::instance($cm2a->cmid)->id, $contextids));
 
         $contextids = provider::get_contexts_for_userid($users[1]->id)->get_contextids();
         $this->assertCount(2, $contextids);
-        $this->assertTrue(in_array(context_module::instance($cm2a->cmid)->id, $contextids));
-        $this->assertTrue(in_array(context_module::instance($cm2b->cmid)->id, $contextids));
+        $this->assertTrue(in_array(\context_module::instance($cm2a->cmid)->id, $contextids));
+        $this->assertTrue(in_array(\context_module::instance($cm2b->cmid)->id, $contextids));
 
         $contextids = provider::get_contexts_for_userid($users[2]->id)->get_contextids();
         $this->assertCount(1, $contextids);
-        $this->assertTrue(in_array(context_module::instance($cm2b->cmid)->id, $contextids));
+        $this->assertTrue(in_array(\context_module::instance($cm2b->cmid)->id, $contextids));
 
         $contextids = provider::get_contexts_for_userid($users[3]->id)->get_contextids();
         $this->assertCount(1, $contextids);
-        $this->assertTrue(in_array(context_module::instance($cm2b->cmid)->id, $contextids));
+        $this->assertTrue(in_array(\context_module::instance($cm2b->cmid)->id, $contextids));
     }
 
     public function test_delete_data_for_all_users_in_context() {
@@ -134,7 +137,7 @@ class mod_mediagallery_privacy_testcase extends provider_testcase {
         $this->create_gallery($cm1a, $users[0]);
         $this->create_gallery($cm1b, $users[1]);
 
-        provider::delete_data_for_all_users_in_context(context_module::instance($cm1b->cmid));
+        provider::delete_data_for_all_users_in_context(\context_module::instance($cm1b->cmid));
         $this->assertTrue($DB->record_exists('mediagallery_gallery', ['userid' => $users[0]->id, 'instanceid' => $cm1a->id]));
         $this->assertFalse($DB->record_exists('mediagallery_gallery', ['userid' => $users[1]->id, 'instanceid' => $cm1b->id]));
     }
@@ -159,16 +162,16 @@ class mod_mediagallery_privacy_testcase extends provider_testcase {
         $fs->create_file_from_string([
             'contextid' => $cm1actx->id,
             'component' => 'mod_mediagallery',
-            'filearea'  => 'item',
-            'itemid'    => $item->id,
-            'filepath'  => '/',
-            'filename'  => 'example.jpg',
+            'filearea' => 'item',
+            'itemid' => $item->id,
+            'filepath' => '/',
+            'filename' => 'example.jpg',
         ], 'image contents (not really)');
 
         provider::delete_data_for_user(new approved_contextlist($users[0], 'mod_lightboxgallery', [
-            context_course::instance($c1->id)->id,
-            context_module::instance($cm1a->cmid)->id,
-            context_module::instance($cm1b->cmid)->id,
+            \context_course::instance($c1->id)->id,
+            \context_module::instance($cm1a->cmid)->id,
+            \context_module::instance($cm1b->cmid)->id,
         ]));
 
         $this->assertFalse($DB->record_exists('mediagallery_gallery', ['userid' => $users[0]->id, 'instanceid' => $cm1a->id]));
@@ -188,16 +191,17 @@ class mod_mediagallery_privacy_testcase extends provider_testcase {
         $cm1c = $dg->create_module('mediagallery', ['course' => $c1]);
         $users = $this->create_users(2);
 
-        $cm1actx = context_module::instance($cm1a->cmid);
-        $cm1bctx = context_module::instance($cm1b->cmid);
-        $cm1cctx = context_module::instance($cm1c->cmid);
+        $cm1actx = \context_module::instance($cm1a->cmid);
+        $cm1bctx = \context_module::instance($cm1b->cmid);
+        $cm1cctx = \context_module::instance($cm1c->cmid);
 
         $gallery1a = $this->create_gallery($cm1a, $users[0]);
         $gallery1a2 = $this->create_gallery($cm1a, $users[1]);
         $gallery1b = $this->create_gallery($cm1b, $users[1]);
         $gallery1c = $this->create_gallery($cm1c, $users[0]);
 
-        provider::export_user_data(new approved_contextlist($users[0], 'mod_mediagallery', [$cm1actx->id, $cm1bctx->id, $cm1cctx->id]));
+        provider::export_user_data(new approved_contextlist($users[0], 'mod_mediagallery',
+                                                            [$cm1actx->id, $cm1bctx->id, $cm1cctx->id]));
 
         $subcontext = static::get_subcontext($cm1a, (object)['id' => $gallery1a->id, 'name' => $gallery1a->name]);
         $data = writer::with_context($cm1actx)->get_data($subcontext);
@@ -213,7 +217,8 @@ class mod_mediagallery_privacy_testcase extends provider_testcase {
         $this->assertEquals($gallery1c->name, $data->name);
 
         writer::reset();
-        provider::export_user_data(new approved_contextlist($users[1], 'mod_mediagallery', [$cm1actx->id, $cm1bctx->id, $cm1cctx->id]));
+        provider::export_user_data(new approved_contextlist($users[1], 'mod_mediagallery',
+                                                            [$cm1actx->id, $cm1bctx->id, $cm1cctx->id]));
 
         $subcontext = static::get_subcontext($cm1a, (object)['id' => $gallery1a2->id, 'name' => $gallery1a2->name]);
         $data = writer::with_context($cm1actx)->get_data($subcontext);
@@ -234,7 +239,7 @@ class mod_mediagallery_privacy_testcase extends provider_testcase {
      *
      * @param int $itemid The item ID.
      * @param int $userid The user ID.
-     * @param bool If the user liked the item.
+     * @param bool $liked If the user liked the item.
      * @return stdClass
      */
     protected function create_userfeedback($itemid, $userid, $liked = false) {

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023060200;
-$plugin->requires  = 2022041200;
+$plugin->version = 2023060200;
+$plugin->requires = 2022041200;
 $plugin->component = 'mod_mediagallery';
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '4.0.2';
+$plugin->maturity = MATURITY_STABLE;
+$plugin->release = '4.0.2';

--- a/view.php
+++ b/view.php
@@ -28,7 +28,7 @@ require_once(dirname(__FILE__).'/lib.php');
 require_once(dirname(__FILE__).'/locallib.php');
 
 $id = optional_param('id', 0, PARAM_INT); // A course_module id.
-$m  = optional_param('m', 0, PARAM_INT); // A mediagallery id.
+$m = optional_param('m', 0, PARAM_INT); // A mediagallery id.
 $g = optional_param('g', 0, PARAM_INT); // A mediagallery_gallery id.
 $action = optional_param('action', 'viewcollection', PARAM_ALPHA);
 $page = optional_param('page', 0, PARAM_INT);
@@ -56,18 +56,18 @@ if ($g) {
     $m = $gallery->instanceid;
     $options['viewcontrols'] = 'item';
     $mediagallery = $gallery->get_collection();
-    $course     = $DB->get_record('course', array('id' => $mediagallery->course), '*', MUST_EXIST);
+    $course = $DB->get_record('course', array('id' => $mediagallery->course), '*', MUST_EXIST);
     $cm = $mediagallery->cm;
 } else if ($id) {
-    $cm         = get_coursemodule_from_id('mediagallery', $id, 0, false, MUST_EXIST);
-    $course     = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
+    $cm = get_coursemodule_from_id('mediagallery', $id, 0, false, MUST_EXIST);
+    $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
     $mediagallery = new \mod_mediagallery\collection($cm->instance);
 } else if ($m) {
     $mediagallery = new \mod_mediagallery\collection($m);
-    $course     = $DB->get_record('course', array('id' => $mediagallery->course), '*', MUST_EXIST);
-    $cm         = get_coursemodule_from_instance('mediagallery', $mediagallery->id, $course->id, false, MUST_EXIST);
+    $course = $DB->get_record('course', array('id' => $mediagallery->course), '*', MUST_EXIST);
+    $cm = get_coursemodule_from_instance('mediagallery', $mediagallery->id, $course->id, false, MUST_EXIST);
 } else {
-    print_error('missingparameter');
+    throw new \moodle_exception('missingparameter');
 }
 
 // The single collection type was contributed by github user eSrem.
@@ -85,7 +85,7 @@ if ($mediagallery->colltype == "single") {
             $options['viewcontrols'] = 'item';
             break;
         default: // More than one, delete others.
-            print_error('toomany', 'mod_mediagallery');
+            throw new \moodle_exception('toomany', 'mod_mediagallery');
             break;
     }
 }


### PR DESCRIPTION
This change fixes the code checker warnings that are easy to address, and adds a script for running moodle-plugin-ci through GitHub Actions, running the checks that currently pass.

I've only minimally tested it, but I don't think there's too much to go wrong.  Check lib.php line ~ 451 though, to make sure I've understood the precedence difference between "or" and "||".  The reason I've deleted style.css line ~ 79 "width: 120px;" is that it's a duplicate.